### PR TITLE
import os for access to os.path.join() on line 4

### DIFF
--- a/pkuseg/process_data.py
+++ b/pkuseg/process_data.py
@@ -1,3 +1,5 @@
+import os
+
 def tocrfoutput(config, readpath, writedatapath, rawdatapath):
     with open(os.path.join(config.modelDir, "tagIndex.txt")) as tagfile:
         lines = tagfile.readlines()


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/lancopku/pkuseg-python on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./pkuseg/process_data.py:2:15: F821 undefined name 'os'
    with open(os.path.join(config.modelDir, "tagIndex.txt")) as tagfile:
              ^
1     F821 undefined name 'os'
1
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree